### PR TITLE
Restructure

### DIFF
--- a/R/aggregate_landings.R
+++ b/R/aggregate_landings.R
@@ -332,6 +332,13 @@ aggregate_landings <- function(landingsData,
   print(gearList)
 
 
+  #############################################################################
+  #############################################################################
+  #############################################################################
+  ################################# UNCLASSIFIEDS #############################
+  #############################################################################
+  #############################################################################
+  #############################################################################
 
   ## Aggregate UNclassified category for each gear type
   # We aggregate to the same level that the MARKET_CODE was aggregated. Either QTR or annual
@@ -383,7 +390,8 @@ aggregate_landings <- function(landingsData,
   }
 
 
-  # now deal with "other gear" category which should have market categories aggregated annually rather than by QTR.
+  # now deal with UNCLASSIFIEDS in the "other gear" category which should have
+  # market categories aggregated annually rather than by QTR or SEMESTER.
   # By definition other gear category will have few landings and therefore aggregated to annual
   # we need to aggregate UN category to annual so we can expand
   # aggregate QTR/SEMESTER to annual. Code QTR = 0
@@ -406,7 +414,7 @@ aggregate_landings <- function(landingsData,
   #.b. dont have any landings for other market categories. Cant obtain a scaling factor
   # so we need to check for this prior to expanding
 
-  print("1")
+
   # unclassified over NEGEAR and season (QTR)
   # select all cases where we have UNclassified landings but no length samples
   unclass <- data$landings %>%

--- a/R/plot_market_code_by_time.R
+++ b/R/plot_market_code_by_time.R
@@ -34,21 +34,25 @@ plot_market_code_by_time <- function(data,plotID,outputDir,outputPlots=T,aggrega
 
     dev.off()
 
-    png(paste0(outputDir,"/",plotID+1,"_market_category_",aggregate_to,"_length_distribution_",as.character(gearType),",.png"))
 
     # Take a look at length distribution by QTR and MARKET CODE
     d <- data$lengthData %>% dplyr::filter(NEGEAR == gearType) %>%
       dplyr::group_by(MARKET_CODE,.data[[aggregate_to]],LENGTH) %>%
-      dplyr::summarise(numlens=sum(as.numeric(NUMLEN)))
+      dplyr::summarise(numlens=sum(as.numeric(NUMLEN)),.groups = "drop")
 
-    p <-   ggplot2::ggplot(data = d) +
-      ggplot2::geom_bar(stat="identity",mapping= ggplot2::aes(x=LENGTH,y=numlens),na.rm=T) +
-      ggplot2::facet_grid(rows=ggplot2::vars(.data[[aggregate_to]]),cols=ggplot2::vars(MARKET_CODE)) +
-      ggplot2::ggtitle(paste0("By ",aggregate_to," and MARKET_CODE  (gear type = ",as.character(gearType),")")) +
-      ggplot2::ylab("Distribution of all length samples")
-    print(p)
+    # check to see if any lengths
+    if(nrow(d) > 0) {
+      png(paste0(outputDir,"/",plotID+1,"_market_category_",aggregate_to,"_length_distribution_",as.character(gearType),",.png"))
 
-    dev.off()
+      p <-   ggplot2::ggplot(data = d) +
+        ggplot2::geom_bar(stat="identity",mapping= ggplot2::aes(x=LENGTH,y=numlens),na.rm=T) +
+        ggplot2::facet_grid(rows=ggplot2::vars(.data[[aggregate_to]]),cols=ggplot2::vars(MARKET_CODE)) +
+        ggplot2::ggtitle(paste0("By ",aggregate_to," and MARKET_CODE  (gear type = ",as.character(gearType),")")) +
+        ggplot2::ylab("Distribution of all length samples")
+      print(p)
+
+      dev.off()
+    }
 
     png(paste0(outputDir,"/",plotID+2,"_market_category_",aggregate_to,"_number_samples_",as.character(gearType),",.png"))
 


### PR DESCRIPTION
* Reordered code in `aggregate_landings` to deal with `otherGear` category after other gearTypes since if no length samples are availabable at al for a gearType they are collapsed into the `otherGear` category.
* check for absence of length samples for gearTypes
