### PR TITLE
Bug expand to number

### DIFF
--- a/R/aggregate_landings.R
+++ b/R/aggregate_landings.R
@@ -59,11 +59,6 @@ aggregate_landings <- function(channel,
   # write function call to log file
   write_to_logfile(outputDir,logfile,data=deparse(dbutils::capture_function_call()),label="Arguments passed to aggregate_landings:",append=F)
 
-  ## CHECKS QA/QC #################################################
-  # Perform data checks, qa/qc and return summarized data as a list
-  data <- checks_qa_qc(landingsData,lengthData,speciesName,aggregate_to,outputDir,logfile)
-
-  speciesRules <- expand_species_rules(speciesRules,outputDir,logfile)
 
   if (is.null(speciesName) & is.null(speciesRules)){
     stop("Missing species Name: The species name must be present in EITHER the argument `speciesName` or `speciesRules$speciesName` ")
@@ -73,6 +68,13 @@ aggregate_landings <- function(channel,
     speciesName <- speciesRules$speciesName
   }
 
+  ## CHECKS QA/QC #################################################
+  # Perform data checks, qa/qc and return summarized data as a list
+  data <- checks_qa_qc(landingsData,lengthData,speciesName,aggregate_to,outputDir,logfile)
+
+  speciesRules <- expand_species_rules(speciesRules,outputDir,logfile)
+
+  # plot histogram of landings (and lengths) over time by QTR
   plot_landings_by_type(speciesRules$speciesName,data$landings,1,outputPlots,outputDir,"3a",type="QTR")
   plot_lengths_by_type(speciesRules$speciesName,data$landings,1,outputPlots,outputDir,"3c",type="QTR")
 

--- a/R/calc_numbers_at_age.r
+++ b/R/calc_numbers_at_age.r
@@ -3,7 +3,7 @@
 #'Given the landings (expanded by length), the age-length key and the length-weight relationship,
 #'the number of fish at a given age is calculated
 #'
-#'@param expLandings Tibble. Expanded langings by length (from \code{expand_landings_to_lengths})
+#'@param expLandings Tibble. Expanded landings by length (from \code{expand_landings_to_lengths})
 #'@param ageLengthKeys Tibble. Age Length Keys (from \code{create_yr_semester_age_length_key}
 #'@param lengthWeightParams List. alpha = intercept, betas = slope(s), var = residual variance used to formulate the mean (?see Notes section below)
 #'

--- a/R/calc_numbers_at_length.r
+++ b/R/calc_numbers_at_length.r
@@ -91,7 +91,7 @@ calc_numbers_at_length <- function(expLandings,lengthWeightParams){
     }
 
   } else if (numFits == 1) { # ANYTHING -> year
-print("########################## HERE ##########################")
+
     for (it in 1:numFits) {
       lengthWeightPs <- lengthWeightParameters
       lengthWeightPs$betas <- lengthWeightParameters$betas[it]

--- a/R/expand_to_num.R
+++ b/R/expand_to_num.R
@@ -4,11 +4,11 @@
 #' length-weight relationship.
 #'
 #' @param fishLength Numeric vector. Lengths of fish in group
-#' @param weight Numeric vector. Landings total for group (metric tons)
+#' @param weight Numeric vector. Landings total for group (kg)
 #' @param lengthWeightParams List (3). List. alpha = intercept, betas = slope(s), var = residual variance used to formulate the mean
-#' Assumes the weight of individual fish is in kgs
+#' Assumes the weight of individual fish is in kg
 #' @param flag Character. Which feature to calculate. Either "numbers" (estimate number of fish)
-#'  or "fishweight" (estmate the weight of an idividual fish)
+#'  or "fishweight" (estimate the weight of an individual fish)
 #'
 #' @return vector
 #' \item{fishWeight}{scaled landings for fish of specified \code{fishLength}}
@@ -28,12 +28,15 @@ expand_to_num <- function(fishLength,weight,lengthWeightParams,flag) {
   sigma2 <- as.double(lengthWeightParams$var)
 
   # vector of weight of individual fish (in the sample) of a given length
-  # in metric tons
-  kgToMt <- 1000
+  # in kg
+
+  # length weight relationship in kg - cm
+  # weight assumed to be in kg
   fishWeight <- (alpha*fishLength^beta)*exp(sigma2/2)
 
   # number of fish
-  fishnum <- weight/(fishWeight/kgToMt)
+  #fishnum <- weight/(fishWeight/kgToMt)
+  fishnum <- weight/fishWeight
 
   if (flag == "numbers") {
     output <- fishnum

--- a/R/fit_length_weight.R
+++ b/R/fit_length_weight.R
@@ -144,10 +144,29 @@ fit_length_weight <- function(lengthWeightData,speciesName,speciesRules,outputDi
 
   if(!is.null(outputDir)) {
     for (mod in models) {
-      if (mod == "SINGLE") {next}
+
       if(!suppressMessages){
         message(paste0("Creating plots for ",mod, " in output folder ..."))
       }
+
+      if (mod == "SINGLE") {
+        textFitH0 <- c(paste0("Common slope (red): W = ",signif(exp(fits$SINGLE$coefficients[1]),6),"L^",signif(fits$SINGLE$coefficients[2],6)))
+        xmin = min(modelData[[mod]]$LENGTH)
+        ymax = max(modelData[[mod]]$INDWT)
+
+        png(paste0(outputDir,"/length_weight_relationship_",speciesName,"-",mod,".png"),width = 1000,height = 1000,units="px")
+        p <- ggplot2::ggplot(data = modelData[[mod]], ggplot2::aes(x=LENGTH, y = INDWT, color = as.factor(SEX))) +
+          ggplot2::geom_point(shape = 1) +
+          ggplot2::geom_line(ggplot2::aes(y = predWt),color = "red") +
+          ggplot2::xlab("Length (cm)") +
+          ggplot2::ylab("Weight (kg)") +
+          ggplot2::labs(title = paste0("Length-weight (SVDBS) relationship for ",speciesName, " by ",mod),color="SEX") +
+          ggplot2::geom_text(ggplot2::aes(x=xmin,y=.9*ymax,label = textFitH0),show.legend = F,size=3,color="black",hjust="inward")
+        print(p)
+        dev.off()
+        next
+      }
+
 
       ncoefs <- length(fits[[mod]]$coefficients)
       coeffs <- fits[[mod]]$coefficients

--- a/R/get_species_object.r
+++ b/R/get_species_object.r
@@ -45,6 +45,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- NA
     speciesRules$startDate <- NA
     speciesRules$stock <- NA
+    speciesRules$maxAge <- NA
 
   } else if (species_itis == 172909) { # Yellowtail
     speciesRules <- list()
@@ -72,6 +73,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1973
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 8
 
 
   } else if (species_itis == 172414 ) { #Mackerel
@@ -102,6 +104,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1992
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 10
 
 
   } else if (species_itis == 161722 ) { #Herring
@@ -133,6 +136,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester","gear")
     speciesRules$startDate <- 1965
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 8
 
 
   } else if (species_itis == 164744 ) { #Haddock
@@ -162,6 +166,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c()
     speciesRules$startDate <- 1964
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 15
 
 
 
@@ -192,6 +197,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1964
     speciesRules$stock <- "GB"
+    speciesRules$maxAge <- 7
 
   } else if (species_itis == 172905 & stock == "SNEMA" ) { #Winter flounder SNEMA
     speciesRules <- list()
@@ -219,6 +225,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1982
     speciesRules$stock <- "SNEMA"
+    speciesRules$maxAge <- 7
 
   } else if (species_itis == 172905 & stock == "" ) { #Winter flounder dummy stock
     speciesRules <- list()
@@ -246,6 +253,8 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1982
     speciesRules$stock <- "SNEMA"
+    speciesRules$maxAge <- 7
+
 
 
   } else if (species_itis == 164712) { # Cod (GB).  East + West(561-562) regions
@@ -274,6 +283,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1981
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 15
 
 
   } else if (species_itis == 160617) { # spiny dog
@@ -386,6 +396,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeData <- "survey"
     speciesRules$AgeLengthKey <- c("year","semester")
     speciesRules$startDate <- 1955
+    speciesRules$maxAge <- 8
 
 
   } else if (species_itis == 164499) { # monkfish
@@ -414,6 +425,7 @@ get_species_object <- function(species_itis = NULL, stock = NA) {
     speciesRules$AgeLengthKey <- c("semester")
     speciesRules$startDate <- NA
     speciesRules$stock <- NULL
+    speciesRules$maxAge <- 10
 
 
   } else if (species_itis == 167687) { # black sea bass

--- a/man/calc_numbers_at_age.Rd
+++ b/man/calc_numbers_at_age.Rd
@@ -7,7 +7,7 @@
 calc_numbers_at_age(expLandings, ageLenKeys, lengthWeightParams)
 }
 \arguments{
-\item{expLandings}{Tibble. Expanded langings by length (from \code{expand_landings_to_lengths})}
+\item{expLandings}{Tibble. Expanded landings by length (from \code{expand_landings_to_lengths})}
 
 \item{lengthWeightParams}{List. alpha = intercept, betas = slope(s), var = residual variance used to formulate the mean (?see Notes section below)}
 


### PR DESCRIPTION
## Code

* `calc_numbers_at_length` bug.  landings were in kg but assumed they were in in metric tons so scaling off by 1000.
* Added `maxAge` (maximim age species reaches) to `get_species_object`
* Added output plot `fit_length_weight` to display all data pooled (single fit)